### PR TITLE
fix: check CRC and member size stored in trailer

### DIFF
--- a/cmd/glzip/compress.go
+++ b/cmd/glzip/compress.go
@@ -23,7 +23,8 @@ func compress(file string, output *os.File, opt options) (err error) {
 	}
 
 	defer func() {
-		if e := output.Close(); e != nil {
+		e := output.Close()
+		if e != nil {
 			err = e
 		}
 	}()
@@ -31,8 +32,10 @@ func compress(file string, output *os.File, opt options) (err error) {
 	writerOpt := &lzip.WriterOptions{DictSize: uint32(opt.dictionarySize)}
 
 	bufWriter := bufio.NewWriter(output)
+
 	defer func() {
-		if e := bufWriter.Flush(); e != nil {
+		e := bufWriter.Flush()
+		if e != nil {
 			err = e
 		}
 	}()
@@ -43,7 +46,8 @@ func compress(file string, output *os.File, opt options) (err error) {
 	}
 
 	defer func() {
-		if e := writer.Close(); e != nil {
+		e := writer.Close()
+		if e != nil {
 			err = e
 		}
 	}()
@@ -54,7 +58,8 @@ func compress(file string, output *os.File, opt options) (err error) {
 	}
 
 	defer func() {
-		if e := input.Close(); e != nil {
+		e := input.Close()
+		if e != nil {
 			err = e
 		}
 	}()
@@ -64,7 +69,8 @@ func compress(file string, output *os.File, opt options) (err error) {
 	}
 
 	if !opt.keep {
-		if err := os.Remove(file); err != nil {
+		err := os.Remove(file)
+		if err != nil {
 			return err
 		}
 	}

--- a/cmd/glzip/main.go
+++ b/cmd/glzip/main.go
@@ -12,6 +12,7 @@ import (
 
 func main() {
 	flag.Parse()
+
 	args := flag.Args()
 
 	if opt.version {
@@ -32,14 +33,16 @@ func main() {
 
 	if !opt.decompress {
 		for _, file := range args {
-			if err := compress(file, output, opt); err != nil {
+			err := compress(file, output, opt)
+			if err != nil {
 				fmt.Fprintf(os.Stderr, "glzip: %v\n", err)
 				os.Exit(1)
 			}
 		}
 	} else {
 		for _, file := range args {
-			if err := uncompress(file, output, opt); err != nil {
+			err := uncompress(file, output, opt)
+			if err != nil {
 				fmt.Fprintf(os.Stderr, "glzip: %v\n", err)
 				os.Exit(1)
 			}

--- a/cmd/glzip/main_test.go
+++ b/cmd/glzip/main_test.go
@@ -32,7 +32,8 @@ func copyFile(srcFile, dstFile string) error {
 	}
 
 	defer func() {
-		if e := src.Close(); e != nil {
+		e := src.Close()
+		if e != nil {
 			err = e
 		}
 	}()
@@ -43,7 +44,8 @@ func copyFile(srcFile, dstFile string) error {
 	}
 
 	defer func() {
-		if e := dst.Close(); e != nil {
+		e := dst.Close()
+		if e != nil {
 			err = e
 		}
 	}()
@@ -73,7 +75,8 @@ func TestCLI(t *testing.T) {
 	}
 
 	defer func() {
-		if err := os.Remove("glzip"); err != nil {
+		err := os.Remove("glzip")
+		if err != nil {
 			t.Fatal(err)
 		}
 	}()

--- a/cmd/glzip/uncompress.go
+++ b/cmd/glzip/uncompress.go
@@ -20,7 +20,8 @@ func uncompress(file string, output *os.File, opt options) (err error) {
 	}
 
 	defer func() {
-		if e := input.Close(); e != nil {
+		e := input.Close()
+		if e != nil {
 			err = e
 		}
 	}()
@@ -42,7 +43,8 @@ func uncompress(file string, output *os.File, opt options) (err error) {
 	}
 
 	defer func() {
-		if e := output.Close(); e != nil {
+		e := output.Close()
+		if e != nil {
 			err = e
 		}
 	}()
@@ -52,7 +54,8 @@ func uncompress(file string, output *os.File, opt options) (err error) {
 	}
 
 	if !opt.keep {
-		if err := os.Remove(file); err != nil {
+		err := os.Remove(file)
+		if err != nil {
 			return err
 		}
 	}

--- a/example_test.go
+++ b/example_test.go
@@ -54,7 +54,8 @@ func ExampleReader() {
 	}
 
 	defer func() {
-		if err := file.Close(); err != nil {
+		err := file.Close()
+		if err != nil {
 			log.Fatal(err)
 		}
 	}()
@@ -80,13 +81,15 @@ func ExampleWriter() {
 	const text = "The quick brown fox jumps over the lazy dog."
 
 	var buf bytes.Buffer
+
 	writer := lzip.NewWriter(&buf)
 
 	if _, err := io.WriteString(writer, text); err != nil {
 		log.Fatal(err)
 	}
 
-	if err := writer.Close(); err != nil {
+	err := writer.Close()
+	if err != nil {
 		log.Fatal(err)
 	}
 

--- a/reader.go
+++ b/reader.go
@@ -60,6 +60,7 @@ func NewReader(r io.Reader) (*Reader, error) {
 	}
 
 	var lzmaHeader [lzma.HeaderLen]byte
+
 	lzmaHeader[0] = lzma.Properties{LC: 3, LP: 0, PB: 2}.Code()
 	binary.LittleEndian.PutUint32(lzmaHeader[1:5], dictSize)
 	copy(lzmaHeader[5:], rb[len(rb)-16:len(rb)-8])
@@ -85,39 +86,44 @@ func NewReader(r io.Reader) (*Reader, error) {
 
 // Read reads uncompressed data from the stream.
 func (z *Reader) Read(p []byte) (n int, err error) {
-	for n == 0 {
+	for {
 		n, err = z.decompressor.Read(p)
-		if err != nil {
-			return n, err
+
+		if n > 0 {
+			z.crc = crc32.Update(z.crc, crc32.IEEETable, p[:n])
+			z.dataSize += uint64(n)
+
+			return n, nil
 		}
 
-		z.crc = crc32.Update(z.crc, crc32.IEEETable, p[:n])
-		z.dataSize += uint64(n)
-
-		if !errors.Is(err, io.EOF) {
-			return n, err
+		if err == nil {
+			continue
 		}
 
-		var trailer [trailerSize]byte
-		if _, err := io.ReadFull(z.r, trailer[:]); err != nil {
-			return n, err
+		if errors.Is(err, io.EOF) {
+			var trailer [trailerSize]byte
+			if _, err := io.ReadFull(z.r, trailer[:]); err != nil {
+				return n, err
+			}
+
+			crc := binary.LittleEndian.Uint32(trailer[:4])
+			if crc != z.crc {
+				return n, &InvalidCRCError{crc}
+			}
+
+			dataSize := binary.LittleEndian.Uint64(trailer[4:12])
+			if dataSize != z.dataSize {
+				return n, &InvalidDataSizeError{dataSize}
+			}
+
+			memberSize := binary.LittleEndian.Uint64(trailer[12:])
+			if memberSize != z.memberSize {
+				return n, &InvalidMemberSizeError{memberSize}
+			}
+
+			return n, io.EOF
 		}
 
-		crc := binary.LittleEndian.Uint32(trailer[:4])
-		if crc != z.crc {
-			return n, &InvalidCRCError{crc}
-		}
-
-		dataSize := binary.LittleEndian.Uint64(trailer[4:12])
-		if dataSize != z.dataSize {
-			return n, &InvalidDataSizeError{dataSize}
-		}
-
-		memberSize := binary.LittleEndian.Uint64(trailer[12:])
-		if memberSize != z.memberSize {
-			return n, &InvalidMemberSizeError{memberSize}
-		}
+		return n, err
 	}
-
-	return n, nil
 }

--- a/reader_test.go
+++ b/reader_test.go
@@ -142,3 +142,67 @@ func TestReaderNonZeroFirstByte(t *testing.T) {
 		t.Error("unexpected success")
 	}
 }
+
+func TestReadInvalidCRC(t *testing.T) {
+	t.Parallel()
+
+	file, err := os.Open("testdata/fox_bcrc.lz")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	reader, err := lzip.NewReader(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+
+	_, err = io.Copy(&buf, reader)
+	if err == nil {
+		t.Fatal("unexpected success")
+	}
+
+	var invalidCRCError *lzip.InvalidCRCError
+	if !errors.As(err, &invalidCRCError) {
+		t.Fatal("unexpected error type")
+	}
+
+	const expected = 0xEB50_CC6B
+
+	if crc := invalidCRCError.CRC; crc != expected {
+		t.Errorf("expected CRC `%v`, got `%v`", expected, crc)
+	}
+}
+
+func TestReadInvalidMemberSize(t *testing.T) {
+	t.Parallel()
+
+	file, err := os.Open("testdata/fox_mes81.lz")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	reader, err := lzip.NewReader(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+
+	_, err = io.Copy(&buf, reader)
+	if err == nil {
+		t.Fatal("unexpected success")
+	}
+
+	var invalidMemberSizeError *lzip.InvalidMemberSizeError
+	if !errors.As(err, &invalidMemberSizeError) {
+		t.Fatal("unexpected error type")
+	}
+
+	const expected = 81
+
+	if memberSize := invalidMemberSizeError.MemberSize; memberSize != expected {
+		t.Errorf("expected member size `%v`, got `%v`", expected, memberSize)
+	}
+}

--- a/writer_test.go
+++ b/writer_test.go
@@ -25,6 +25,7 @@ func TestWriter(t *testing.T) {
 	text := string(data)
 
 	var buf bytes.Buffer
+
 	writer := lzip.NewWriter(&buf)
 
 	n, err := io.WriteString(writer, text)
@@ -160,6 +161,7 @@ func TestVerifyWriterOptions(t *testing.T) {
 	}
 
 	var expected uint32 = (1 << 12) - 1
+
 	opt = &lzip.WriterOptions{expected}
 
 	err := opt.Verify()


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->

<!--
If it resolves an open issue, link to the issue here, otherwise remove this
line.
-->

> [!IMPORTANT]
> The size of the original uncompressed data stored in the trailer has not yet been checked.

## Additional context

<!-- If you have any other context, describe them here. -->
#64

## Checklist

- [ ] I have read the [Contribution Guide].
- [ ] I agree to follow the [Code of Conduct].

[Contribution Guide]: https://github.com/sorairolake/lzip-go/blob/develop/CONTRIBUTING.adoc
[Code of Conduct]: https://github.com/sorairolake/lzip-go/blob/develop/CODE_OF_CONDUCT.md
